### PR TITLE
Improve Composer autoloader including.

### DIFF
--- a/bin/slim
+++ b/bin/slim
@@ -9,7 +9,11 @@
 
 declare(strict_types=1);
 
-require __DIR__ . '/../vendor/autoload.php';
+if (file_exists(__DIR__ . '/../../../autoload.php')) {
+    require __DIR__ . '/../../../autoload.php';
+} else {
+    require __DIR__ . '/../vendor/autoload.php';
+}
 
 use Slim\Console\Application;
 


### PR DESCRIPTION
If we want to require Slim Console globally, `require __DIR__ . '/../vendor/autoload.php';` won't work, because in this case the Composer autoloader has a different path.