### PR TITLE
Implement config object

### DIFF
--- a/bin/slim
+++ b/bin/slim
@@ -17,5 +17,11 @@ if (file_exists(__DIR__ . '/../../../autoload.php')) {
     require __DIR__ . '/../vendor/autoload.php';
 }
 
-$app = new Application();
+//Config SHOULD be placed by init command in the project's root directory
+$configDir = dirname(dirname(__DIR__));
+
+$app = new Application($configDir);
+
+//$app->add(new \Slim\Console\Command\InitCommand());
+
 $app->run();

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     "require": {
         "php": "^7.2",
         "symfony/console": "^5.0",
-        "symfony/config": "^5.0"
+        "symfony/config": "^5.0",
+        "ext-json": "*"
     },
     "require-dev": {
         "adriansuter/php-autoload-override": "^1.0",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,3 +1,4 @@
 parameters:
   level: max
   inferPrivatePropertyTypeFromConstructor: true
+  checkGenericClassInNonGenericObjectType: false

--- a/src/Application.php
+++ b/src/Application.php
@@ -10,6 +10,8 @@ declare(strict_types=1);
 
 namespace Slim\Console;
 
+use Slim\Console\Config\Config;
+use Slim\Console\Config\ConfigResolver;
 use Symfony\Component\Console\Application as SymfonyApplication;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -19,9 +21,14 @@ class Application extends SymfonyApplication
 {
     private const VERSION = '0.1';
 
-    public function __construct()
+    /** @var Config|null */
+    protected $config;
+
+    public function __construct(string $configDir)
     {
         parent::__construct('Slim Console', self::VERSION);
+
+        $this->setConfig($configDir);
     }
 
     /**
@@ -47,5 +54,15 @@ class Application extends SymfonyApplication
         }
 
         return parent::doRun($input, $output);
+    }
+
+    public function getConfig(): ?Config
+    {
+        return $this->config;
+    }
+
+    public function setConfig(string $configDir): void
+    {
+        $this->config = (new ConfigResolver($configDir))->loadConfig();
     }
 }

--- a/src/Command/AbstractCommand.php
+++ b/src/Command/AbstractCommand.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ */
+
+declare(strict_types=1);
+
+namespace Slim\Console\Command;
+
+use Slim\Console\Application;
+use Slim\Console\Config\Config;
+use Symfony\Component\Console\Command\Command as SymfonyCommand;
+
+abstract class AbstractCommand extends SymfonyCommand
+{
+    /**
+     * @return Config|null
+     */
+    public function getConfig(): ?Config
+    {
+        $app = $this->getApplication();
+        if ($app instanceof Application === false) {
+            return null;
+        }
+
+        return $app->getConfig();
+    }
+
+    /**
+     * @param string $configDir
+     */
+    public function setConfig(string $configDir): void
+    {
+        $app = $this->getApplication();
+        if ($app instanceof Application) {
+            $app->setConfig($configDir);
+        }
+    }
+}

--- a/src/Command/AbstractCommand.php
+++ b/src/Command/AbstractCommand.php
@@ -3,7 +3,7 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim-Console/blob/0.x/LICENSE.md (MIT License)
  */
 
 declare(strict_types=1);

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -1,0 +1,173 @@
+<?php
+
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @license https://github.com/slimphp/Slim-Console/blob/0.x/LICENSE.md (MIT License)
+ */
+
+declare(strict_types=1);
+
+namespace Slim\Console\Config;
+
+use ArrayAccess;
+
+use function array_key_exists;
+use function array_merge;
+use function ctype_lower;
+use function is_null;
+use function preg_replace;
+use function strtoupper;
+
+class Config implements ArrayAccess
+{
+    private const ENV_PREFIX = 'SLIM_CONSOLE_';
+
+    /**
+     * @var array<mixed>
+     */
+    private $default = [
+        'bootstrapDir'  => DIRECTORY_SEPARATOR . 'app',
+        'commandsDir'   => DIRECTORY_SEPARATOR . 'Application/Commands',
+        'indexDir'  => DIRECTORY_SEPARATOR . 'public',
+        'indexFile' => DIRECTORY_SEPARATOR . 'index.php',
+        'sourceDir' => DIRECTORY_SEPARATOR . 'src',
+    ];
+
+    /**
+     * @var array<mixed>
+     */
+    private $params = [];
+
+    /**
+     * Config constructor.
+     * @param array<mixed> $params
+     * @param string $configDir
+     */
+    public function __construct(array $params = [], string $configDir = '')
+    {
+        if ($configDir !== '') {
+            $this->set('rootDir', $configDir);
+        }
+        $this->setAll($params);
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    public function all(): array
+    {
+        return $this->params;
+    }
+
+    /**
+     * @param array<mixed> $params
+     * @return void
+     */
+    public function setAll(array $params): void
+    {
+        $params = array_merge($this->default, $params);
+
+        foreach ($params as $key => $value) {
+            //Env variables take precedence
+            $this->params[$key] = $this->getEnvironmentVariableValue((string) $key) ?: $this->get('rootDir') . $value;
+        }
+    }
+
+    /**
+     * @param string $key
+     * @return mixed|null
+     */
+    public function get(string $key)
+    {
+        return $this->params[$key] ?? null;
+    }
+
+    /**
+     * @param string $key
+     * @param mixed $value
+     */
+    public function set(string $key, $value): void
+    {
+        $this->params[$key] = $value;
+    }
+
+    /**
+     * @param string $key
+     * @return bool
+     */
+    public function has(string $key): bool
+    {
+        return isset($this->params[$key]);
+    }
+
+    /**
+     * @param string $key
+     */
+    public function delete(string $key): void
+    {
+        unset($this->params[$key]);
+    }
+
+    /**
+     * @param mixed $key
+     * @return bool
+     */
+    public function offsetExists($key): bool
+    {
+        return $this->has($key);
+    }
+
+    /**
+     * @param mixed $key
+     * @return mixed|null
+     */
+    public function offsetGet($key)
+    {
+        return $this->get($key);
+    }
+
+    /**
+     * @param mixed $key
+     * @param mixed $value
+     */
+    public function offsetSet($key, $value): void
+    {
+        $this->set($key, $value);
+    }
+
+    /**
+     * @param mixed $key
+     */
+    public function offsetUnset($key): void
+    {
+        $this->delete($key);
+    }
+
+    /**
+     * @param string $key
+     * @return string|null
+     */
+    private function getEnvironmentVariableValue(string $key): ?string
+    {
+        //Return nothing for unknown keys
+        if (array_key_exists($key, $this->default) === false) {
+            return null;
+        }
+
+        if (ctype_lower($key) === true) {
+            return strtoupper($key);
+        }
+
+        //Convert CamelCase to Snake_Case
+        $key = preg_replace('/(.)(?=[A-Z])/u', '$1' . '_', $key);
+        if (is_null($key)) {
+            return null;
+        }
+
+        $key = self::ENV_PREFIX . strtoupper($key);
+        $value = getenv($key);
+
+        return $value ?: null;
+    }
+}

--- a/src/Config/ConfigResolver.php
+++ b/src/Config/ConfigResolver.php
@@ -1,5 +1,13 @@
 <?php
 
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @license https://github.com/slimphp/Slim-Console/blob/0.x/LICENSE.md (MIT License)
+ */
+
+declare(strict_types=1);
+
 namespace Slim\Console\Config;
 
 use InvalidArgumentException;

--- a/src/Config/ConfigResolver.php
+++ b/src/Config/ConfigResolver.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Slim\Console\Config;
+
+use InvalidArgumentException;
+use ReflectionClass;
+use Slim\Console\Exception\ConfigNotFoundException;
+
+use function array_filter;
+use function file_exists;
+use function file_get_contents;
+use function implode;
+use function is_array;
+use function is_null;
+use function json_decode;
+use function strpos;
+
+class ConfigResolver
+{
+    public const FORMAT_JSON = 'json';
+    public const FORMAT_PHP = 'php';
+    //public const FORMAT_YAML = 'yaml';
+    private const CONFIG_FILENAME = 'slim-console.config';
+
+    /** @var string|null */
+    private $file = null;
+
+    /** @var string */
+    private $dir;
+
+    public function __construct(string $dir)
+    {
+        $this->dir = $dir;
+    }
+
+    public function loadConfig(): ?Config
+    {
+        $this->locateConfig();
+
+        return $this->loadConfigByFormat();
+    }
+
+    public function getFile(): string
+    {
+        return $this->file ?? "";
+    }
+
+    protected function locateConfig(): void
+    {
+        $reflection = new ReflectionClass($this);
+        $filterFormats = function ($value, $key) {
+            return strpos($key, 'FORMAT') === 0;
+        };
+        $formats = array_filter($reflection->getConstants(), $filterFormats, ARRAY_FILTER_USE_BOTH);
+
+        foreach ($formats as $possibleFormat) {
+            $fileName = $this->dir . DIRECTORY_SEPARATOR . self::CONFIG_FILENAME . '.' . $possibleFormat;
+            if (file_exists($fileName)) {
+                $this->file = $fileName;
+
+                break;
+            }
+        }
+
+        if (is_null($this->file)) {
+            throw new ConfigNotFoundException(
+                'Please create config file, supported formats: ' . implode(',', $formats)
+            );
+        }
+    }
+
+    protected function loadConfigByFormat(): ?Config
+    {
+        if (is_null($this->file)) {
+            return null;
+        }
+
+        $format = pathinfo($this->file, PATHINFO_EXTENSION);
+
+        if ($format === self::FORMAT_PHP) {
+            $array = require($this->file);
+            if (is_array($array) === false) {
+                throw new InvalidArgumentException("The file $this->file should return an array");
+            }
+
+            return new Config($array, $this->dir);
+        }
+
+        if ($format === self::FORMAT_JSON) {
+            $string = (string) file_get_contents($this->file);
+            $array = json_decode($string, true);
+            if (json_last_error() !== JSON_ERROR_NONE) {
+                throw new InvalidArgumentException("The file $this->file should be a valid JSON");
+            }
+
+            return new Config($array, $this->dir);
+        }
+
+        return null;
+    }
+}

--- a/src/Exception/ConfigNotFoundException.php
+++ b/src/Exception/ConfigNotFoundException.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ */
+
+declare(strict_types=1);
+
+namespace Slim\Console\Exception;
+
+use Exception;
+
+class ConfigNotFoundException extends Exception
+{
+}

--- a/src/Exception/ConfigNotFoundException.php
+++ b/src/Exception/ConfigNotFoundException.php
@@ -3,7 +3,7 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim-Console/blob/0.x/LICENSE.md (MIT License)
  */
 
 declare(strict_types=1);

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @license https://github.com/slimphp/Slim-Console/blob/0.x/LICENSE.md (MIT License)
+ */
+
 declare(strict_types=1);
 
 namespace Slim\Tests\Console;

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Slim\Tests\Console;
+
+use PHPUnit\Framework\TestCase;
+use Slim\Console\Application;
+use Slim\Console\Config\Config;
+
+class ApplicationTest extends TestCase
+{
+    public function testShouldRunApplication(): void
+    {
+        $configDir = __DIR__ . DIRECTORY_SEPARATOR . 'ExampleConfig' . DIRECTORY_SEPARATOR . 'Php';
+        $app = new Application($configDir);
+
+        $this->assertInstanceOf(Config::class, $app->getConfig());
+    }
+}

--- a/tests/Command/ExampleCommand.php
+++ b/tests/Command/ExampleCommand.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Slim\Tests\Console\Command;
+
+use Slim\Console\Application;
+use Slim\Console\Command\AbstractCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ExampleCommand extends AbstractCommand
+{
+    /**
+    * {@inheritdoc}
+    */
+    protected function configure(): void
+    {
+        $this->setName('example')
+            ->setDescription('Example Test Command Slim Application');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        return 0;
+    }
+}

--- a/tests/Command/ExampleCommand.php
+++ b/tests/Command/ExampleCommand.php
@@ -1,8 +1,13 @@
 <?php
 
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @license https://github.com/slimphp/Slim-Console/blob/0.x/LICENSE.md (MIT License)
+ */
+
 namespace Slim\Tests\Console\Command;
 
-use Slim\Console\Application;
 use Slim\Console\Command\AbstractCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;

--- a/tests/Command/ExampleCommandTest.php
+++ b/tests/Command/ExampleCommandTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Slim\Tests\Console\Command;
+
+use PHPUnit\Framework\TestCase;
+use Slim\Console\Application;
+use Slim\Console\Config\Config;
+
+class ExampleCommandTest extends TestCase
+{
+    public function testShouldLoadWithAccessToConfig(): void
+    {
+        $configDir = dirname(__DIR__) . DIRECTORY_SEPARATOR . 'ExampleConfig' . DIRECTORY_SEPARATOR . 'Php';
+        $command = new ExampleCommand();
+        $command->setApplication(new Application($configDir));
+
+        $this->assertInstanceOf(Config::class, $command->getConfig());
+    }
+}

--- a/tests/Command/ExampleCommandTest.php
+++ b/tests/Command/ExampleCommandTest.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @license https://github.com/slimphp/Slim-Console/blob/0.x/LICENSE.md (MIT License)
+ */
+
 declare(strict_types=1);
 
 namespace Slim\Tests\Console\Command;

--- a/tests/Config/ConfigResolverTest.php
+++ b/tests/Config/ConfigResolverTest.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @license https://github.com/slimphp/Slim-Console/blob/0.x/LICENSE.md (MIT License)
+ */
+
 declare(strict_types=1);
 
 namespace Slim\Tests\Console\Config;

--- a/tests/Config/ConfigResolverTest.php
+++ b/tests/Config/ConfigResolverTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Slim\Tests\Console\Config;
+
+use Slim\Console\Config\Config;
+use PHPUnit\Framework\TestCase;
+use Slim\Console\Config\ConfigResolver;
+use Slim\Console\Exception\ConfigNotFoundException;
+
+use function dirname;
+use function pathinfo;
+
+class ConfigResolverTest extends TestCase
+{
+    public function testShouldResolveJsonConfig(): void
+    {
+        $path = dirname(__DIR__) . DIRECTORY_SEPARATOR . 'ExampleConfig' . DIRECTORY_SEPARATOR . 'Json';
+        $resolver = new ConfigResolver($path);
+
+        $this->assertInstanceOf(Config::class, $resolver->loadConfig());
+        $this->assertEquals(pathinfo($resolver->getFile(), PATHINFO_EXTENSION), ConfigResolver::FORMAT_JSON);
+    }
+
+    public function testShouldResolvePhpConfig(): void
+    {
+        $path = dirname(__DIR__) . DIRECTORY_SEPARATOR . 'ExampleConfig' . DIRECTORY_SEPARATOR . 'Php';
+        $resolver = new ConfigResolver($path);
+
+        $this->assertInstanceOf(Config::class, $resolver->loadConfig());
+        $this->assertEquals(pathinfo($resolver->getFile(), PATHINFO_EXTENSION), ConfigResolver::FORMAT_PHP);
+    }
+
+    public function testShouldThrowExceptionIfConfigCannotBeFound(): void
+    {
+        $path = 'Wrong/Path';
+        $resolver = new ConfigResolver($path);
+
+        $this->expectException(ConfigNotFoundException::class);
+        $resolver->loadConfig();
+    }
+}

--- a/tests/Config/ConfigTest.php
+++ b/tests/Config/ConfigTest.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @license https://github.com/slimphp/Slim-Console/blob/0.x/LICENSE.md (MIT License)
+ */
+
 declare(strict_types=1);
 
 namespace Slim\Tests\Console\Config;

--- a/tests/Config/ConfigTest.php
+++ b/tests/Config/ConfigTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Slim\Tests\Console\Config;
+
+use PHPUnit\Framework\TestCase;
+use Slim\Console\Config\Config;
+
+class ConfigTest extends TestCase
+{
+    /** @var Config */
+    private $config;
+
+    public function setUp(): void
+    {
+        //Suppose that is APP dir
+        $configDir = __DIR__;
+        $this->config = new Config([], $configDir);
+
+        $this->config->set('rootDir', $configDir);
+    }
+    public function testShouldBuildWithDefaultParams(): void
+    {
+        $this->assertArrayHasKey('bootstrapDir', $this->config);
+        $this->assertArrayHasKey('commandsDir', $this->config);
+        $this->assertArrayHasKey('indexDir', $this->config);
+        $this->assertArrayHasKey('indexFile', $this->config);
+        $this->assertArrayHasKey('sourceDir', $this->config);
+    }
+
+    public function testShouldGetValue(): void
+    {
+        $this->assertIsString($this->config->get('rootDir'));
+        $this->assertIsString($this->config['rootDir']);
+        $this->assertFalse(empty($this->config->get('rootDir')));
+        $this->assertFalse(empty($this->config['rootDir']));
+    }
+
+    public function testShouldHasKey(): void
+    {
+        $this->config->set('foo', 'bar');
+        $this->assertTrue($this->config->has('foo'));
+        $this->config->delete('foo');
+
+        $this->config['f'] = 'b';
+        $this->assertIsString($this->config['f']);
+
+        $this->assertFalse($this->config->has('doesnotexist'));
+    }
+
+    public function testShouldDeleteParam(): void
+    {
+        $this->config->set('foo', 'bar');
+        $this->config->set('f', 'b');
+        $this->assertArrayHasKey('foo', $this->config);
+        $this->assertArrayHasKey('f', $this->config);
+
+        $this->config->delete('foo');
+        unset($this->config['f']);
+        $this->assertArrayNotHasKey('foo', $this->config);
+        $this->assertArrayNotHasKey('f', $this->config);
+    }
+
+    public function testShouldGivePrecedenceToEnvVarialbesOfDefaultParams(): void
+    {
+        $this->assertArrayHasKey('sourceDir', $this->config);
+
+        //it is case sensitive
+        putenv('SLIM_CONSOLE_SOURCE_DIR=Source dir taken from env');
+        putenv('SLIM_CONSOLE_INDEX_FILE=Index file taken from env');
+        $config = new Config();
+
+        $this->assertEquals('Source dir taken from env', $config->get('sourceDir'));
+        $this->assertEquals('Index file taken from env', $config->get('indexFile'));
+
+        //Unset env variables
+        putenv('SLIM_CONSOLE_SOURCE_DIR');
+        putenv('SLIM_CONSOLE_INDEX_FILE');
+    }
+
+    public function testShouldAddMoreParametersBeyondDefault(): void
+    {
+        $this->config->set('param1', 'value1');
+        $this->assertArrayHasKey('param1', $this->config);
+
+        $this->config->set('param2', 'value2');
+        $this->assertEquals('value2', $this->config->get('param2'));
+    }
+
+    public function testShouldtheDefaulsHaveAbsolutePaths(): void
+    {
+        $dir = '.';
+        $config = new Config([], $dir);
+        $this->assertEquals([
+            'bootstrapDir' => $dir . DIRECTORY_SEPARATOR . 'app',
+            'commandsDir'  => $dir . DIRECTORY_SEPARATOR . 'Application/Commands',
+            'indexDir'     => $dir . DIRECTORY_SEPARATOR . 'public',
+            'indexFile'    => $dir . DIRECTORY_SEPARATOR . 'index.php',
+            'sourceDir'    => $dir . DIRECTORY_SEPARATOR . 'src',
+            'rootDir'      => $dir,
+        ], $config->all());
+    }
+}

--- a/tests/ExampleConfig/Json/slim-console.config.json
+++ b/tests/ExampleConfig/Json/slim-console.config.json
@@ -1,0 +1,6 @@
+{
+  "customCommandsPath": "src/Application/Commands",
+  "publicPath": "public/index.php",
+  "srcPath": "src",
+  "bootstrapDir": "app"
+}

--- a/tests/ExampleConfig/Php/slim-console.config.php
+++ b/tests/ExampleConfig/Php/slim-console.config.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'bootstrapDir'      => 'app from file',
+    'externalCommands'  => 'Application/Commands',
+    'publicIndexPath'   => 'public/index.php',
+    'srcPath'           => 'src',
+];

--- a/tests/ExampleConfig/Yaml/slim-console.config.yaml
+++ b/tests/ExampleConfig/Yaml/slim-console.config.yaml
@@ -1,0 +1,4 @@
+customCommandsPath: src/Application/Commands
+publicPath: public/index.php
+srcPath: src
+bootstrapDir: app


### PR DESCRIPTION
This is the implementation of #6 

It can be accessed by the Application or Command Object.

Use cases:
```php
$config = $app->getConfig();
$config = $command->getConfig();

//Default params:
$params = [
    'bootstrapDir'   => 'app',
    'commandsDir'    => 'Application/Commands',
    'indexDir'	     => 'public',
    'indexFile'	     => 'index.php',
    'rootDir'	     => 'Absolute path of the project\'s root directory',
    'sourceDir'	     => 'src',
];

//Retrieve value
$config['commandsDir'];
//OR
$config->get('commandsDir');
```

Additional params can be stored as follows:
```php
$config['newParam'] = 'value';
//OR
$config->set('newParam') = 'value';
```

**Supported formats**
- [x] JSON
- [x] PHP
- [ ] Yaml