### PR TITLE
Refactor Exceptions

### DIFF
--- a/bin/slim
+++ b/bin/slim
@@ -11,7 +11,12 @@ declare(strict_types=1);
 
 use Slim\Console\App;
 use Slim\Console\Config\ConfigResolver;
+use Slim\Console\Exception\ConfigException;
+use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
+// Get Current Working Directory
 $cwd = getcwd();
 
 if (file_exists(__DIR__ . '/../../../autoload.php')) {
@@ -20,7 +25,17 @@ if (file_exists(__DIR__ . '/../../../autoload.php')) {
     require __DIR__ . '/../vendor/autoload.php';
 }
 
-$config = (new ConfigResolver())->resolve($cwd);
+// Resolve Config
+try {
+    $config = (new ConfigResolver())->resolve($cwd);
+} catch (ConfigException $e) {
+    $console = new SymfonyStyle(new StringInput(''), new ConsoleOutput());
+    $console->error([
+        'An error occurred while parsing the console configuration:',
+        $e->getMessage(),
+    ]);
+    exit(1);
+}
 
 $app = new App($config);
 $app->run();

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 
 namespace Slim\Console\Config;
 
-use InvalidArgumentException;
+use Slim\Console\Exception\ConfigValidationException;
 
 use function array_merge;
 use function ctype_space;
@@ -133,7 +133,7 @@ class Config
     /**
      * @param array<string, string> $params
      *
-     * @throws InvalidArgumentException
+     * @throws ConfigValidationException
      */
     protected static function validate(array $params): void
     {
@@ -146,23 +146,23 @@ class Config
         ] = $params;
 
         if (!is_string($bootstrapDir) || empty($bootstrapDir) || ctype_space($bootstrapDir)) {
-            throw new InvalidArgumentException('`bootstrapDir` must be a string.');
+            throw new ConfigValidationException('`bootstrapDir` must be a string.');
         }
 
         if (!is_string($indexDir) || empty($indexDir) || ctype_space($indexDir)) {
-            throw new InvalidArgumentException('`indexDir` must be a string.');
+            throw new ConfigValidationException('`indexDir` must be a string.');
         }
 
         if (!is_string($indexFile) || empty($indexFile) || ctype_space($indexFile)) {
-            throw new InvalidArgumentException('`indexFile` must be a string.');
+            throw new ConfigValidationException('`indexFile` must be a string.');
         }
 
         if (!is_string($sourceDir) || empty($sourceDir) || ctype_space($sourceDir)) {
-            throw new InvalidArgumentException('`sourceDir` must be a string.');
+            throw new ConfigValidationException('`sourceDir` must be a string.');
         }
 
         if (!empty($commandsDir) && (!is_string($commandsDir) || ctype_space($commandsDir))) {
-            throw new InvalidArgumentException('`commandsDir` must be a string.');
+            throw new ConfigValidationException('`commandsDir` must be a string.');
         }
     }
 
@@ -171,7 +171,7 @@ class Config
      *
      * @return Config
      *
-     * @throws InvalidArgumentException
+     * @throws ConfigValidationException
      */
     public static function fromArray(array $params): Config
     {
@@ -191,7 +191,7 @@ class Config
     /**
      * @return Config
      *
-     * @throws InvalidArgumentException
+     * @throws ConfigValidationException
      */
     public static function fromEnvironment(): Config
     {

--- a/src/Config/Parser/JSONConfigParser.php
+++ b/src/Config/Parser/JSONConfigParser.php
@@ -10,8 +10,8 @@ declare(strict_types=1);
 
 namespace Slim\Console\Config\Parser;
 
-use InvalidArgumentException;
 use Slim\Console\Config\Config;
+use Slim\Console\Exception\CannotParseConfigException;
 
 use function file_get_contents;
 use function is_array;
@@ -32,13 +32,13 @@ class JSONConfigParser implements ConfigParserInterface
         $parsed = json_decode($contents, true);
 
         if (json_last_error() !== JSON_ERROR_NONE) {
-            throw new InvalidArgumentException(
+            throw new CannotParseConfigException(
                 'Invalid JSON parsed from Slim Console configuration. ' . json_last_error_msg()
             );
         }
 
         if (!is_array($parsed)) {
-            throw new InvalidArgumentException('Slim Console configuration should be an array.');
+            throw new CannotParseConfigException('Slim Console configuration should be an array.');
         }
 
         return Config::fromArray($parsed);

--- a/src/Exception/CannotResolveConfigException.php
+++ b/src/Exception/CannotResolveConfigException.php
@@ -10,9 +10,7 @@ declare(strict_types=1);
 
 namespace Slim\Console\Exception;
 
-use Exception;
-
-class CannotResolveConfigException extends Exception
+class CannotResolveConfigException extends ConfigException
 {
     /**
      * @var string

--- a/src/Exception/ConfigException.php
+++ b/src/Exception/ConfigException.php
@@ -10,6 +10,8 @@ declare(strict_types=1);
 
 namespace Slim\Console\Exception;
 
-class CannotParseConfigException extends ConfigException
+use Exception;
+
+class ConfigException extends Exception
 {
 }

--- a/src/Exception/ConfigValidationException.php
+++ b/src/Exception/ConfigValidationException.php
@@ -10,6 +10,6 @@ declare(strict_types=1);
 
 namespace Slim\Console\Exception;
 
-class CannotParseConfigException extends ConfigException
+class ConfigValidationException extends ConfigException
 {
 }

--- a/tests/Config/ConfigTest.php
+++ b/tests/Config/ConfigTest.php
@@ -10,10 +10,10 @@ declare(strict_types=1);
 
 namespace Slim\Tests\Console\Config;
 
-use InvalidArgumentException;
 use ReflectionClass;
 use ReflectionProperty;
 use Slim\Console\Config\Config;
+use Slim\Console\Exception\ConfigValidationException;
 use Slim\Tests\Console\TestCase;
 
 use function array_merge;
@@ -106,7 +106,7 @@ class ConfigTest extends TestCase
 
         $params = array_merge($defaults, [$param => $value]);
 
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(ConfigValidationException::class);
         $this->expectExceptionMessage("`{$param}` must be a string.");
 
         $validateMethod->invoke(null, $params);

--- a/tests/Config/Parser/JSONConfigParserTest.php
+++ b/tests/Config/Parser/JSONConfigParserTest.php
@@ -10,9 +10,9 @@ declare(strict_types=1);
 
 namespace Slim\Tests\Console\Config\Parser;
 
-use InvalidArgumentException;
 use Slim\Console\Config\ConfigResolver;
 use Slim\Console\Config\Parser\JSONConfigParser;
+use Slim\Console\Exception\CannotParseConfigException;
 use Slim\Tests\Console\TestCase;
 
 use function file_get_contents;
@@ -53,13 +53,15 @@ class JSONConfigParserTest extends TestCase
      * @param string $fileName
      * @param string $expectedExceptionMessage
      */
-    public function testParseThrowsInvalidArgumentException(string $fileName, string $expectedExceptionMessage): void
-    {
+    public function testParseThrowsExceptionWithInvalidConfigFormat(
+        string $fileName,
+        string $expectedExceptionMessage
+    ): void {
         $invalidJsonConfigPath = $this->examplesConfigBasePath
             . DIRECTORY_SEPARATOR . 'invalid-json'
             . DIRECTORY_SEPARATOR . $fileName;
 
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(CannotParseConfigException::class);
         $this->expectExceptionMessage($expectedExceptionMessage);
 
         JSONConfigParser::parse($invalidJsonConfigPath);


### PR DESCRIPTION
This PR adds a base `ConfigException` which all the other exceptions extend so they can be caught more elegantly.

This also adds exception catching in the `bin/slim` file and outputs a pretty message instead of the raw stack trace.